### PR TITLE
[#36] Add Jupyter container into playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,64 @@
 
 ## Playground introduction
 
-The playground is a complete Gravitino Docker runtime environment with `Hive`, `HDFS`, `Trino`, `MySQL`, `PostgreSQL`, and a `Gravitino` server.
+The playground is a complete Gravitino Docker runtime environment with `Hive`, `HDFS`, `Trino`, `MySQL`, `PostgreSQL`, `Jupter`, and a `Gravitino` server.
 
-Depending on your network and computer, startup time may take 3-5 minutes. Once the playground environment has started, you can open <http://localhost:8090> in a browser to access the Gravitino Web UI.
+Depending on your network and computer, startup time may take 3-5 minutes. Once the playground environment has started, you can open [http://localhost:8090](http://localhost:8090) in a browser to access the Gravitino Web UI.
 
 ## Prerequisites
 
-You first need to install git and docker-compose.
+Install Git and Docker Compose.
 
 ## TCP ports used
 
 The playground runs a number of services. The TCP ports used may clash with existing services you run, such as MySQL or Postgres.
 
-    | Docker container      | Ports used     |
-    | playground-gravitino  | 8090 9001      |
-    | playground-hive       | 3307 9000 9083 |
-    | playground-mysql      | 3306           |
-    | playground-postgresql | 5342           |
-    | playground-trino      | 8080           |
+| Docker container      | Ports used     |
+|-----------------------|----------------|
+| playground-gravitino  | 8090 9001      |
+| playground-hive       | 3307 9000 9083 |
+| playground-mysql      | 3306           |
+| playground-postgresql | 5342           |
+| playground-trino      | 8080           |
+| playground-jupyter    | 8888           |
 
 ## Start playground
 
+### Launch all components of playground
 ```shell
 git clone git@github.com:datastrato/gravitino-playground.git
 cd gravitino-playground
 ./launch-playground.sh
 ```
 
+### Launch BigData components of playground
+```shell
+git clone git@github.com:datastrato/gravitino-playground.git
+cd gravitino-playground
+./launch-playground.sh bigdata
+# equivalent to
+./launch-playground.sh hive gravitino trino postgresql mysql spark
+```
+
+### Launch AI components of playground
+```shell
+git clone git@github.com:datastrato/gravitino-playground.git
+cd gravitino-playground
+./launch-playground.sh ai
+# equivalent to
+./launch-playground.sh hive gravitino mysql jupyter
+```
+
+### Launch special component or components of playground
+```shell
+git clone git@github.com:datastrato/gravitino-playground.git
+cd gravitino-playground
+./launch-playground.sh hive|gravitino|trino|postgresql|mysql|spark|jupyter
+```
+
 ## Experiencing Gravitino with Trino SQL
 
-1. Login to the Gravitino playground Trino Docker container using the following command.
+1. Log in to the Gravitino playground Trino Docker container using the following command:
 
 ```shell
 docker exec -it playground-trino bash
@@ -43,7 +71,7 @@ docker exec -it playground-trino bash
 2. Open the Trino CLI in the container.
 
 ```shell
-trino@d2bbfccc7432:/$ trino
+trino@container_id:/$ trino
 ```
 
 ## Example
@@ -82,9 +110,9 @@ SHOW TABLES from catalog_hive.company;
 
 ### Cross-catalog queries
 
-In a company, there may be different departments using different data stacks. In this example, the HR department uses Apache Hive to store its data and the sales department uses PostgreSQL to store its data. You can run some interesting queries by joining the two departments' data together with Gravitino.
+In a company, there may be different departments using different data stacks. In this example, the HR department uses Apache Hive to store its data and the sales department uses PostgreSQL. You can run some interesting queries by joining the two departments' data together with Gravitino.
 
-If you want to know which employee has the largest sales amount, you can run this SQL.
+To know which employee has the largest sales amount, run this SQL:
 
 ```SQL
 SELECT given_name, family_name, job_title, sum(total_amount) AS total_sales
@@ -96,7 +124,7 @@ ORDER BY total_sales DESC
 LIMIT 1;
 ```
 
-If you want to know the top customers who bought the most by state, you can run this SQL.
+To know the top customers who bought the most by state, run this SQL:
 
 ```SQL
 SELECT customer_name, location, SUM(total_amount) AS total_spent
@@ -108,10 +136,10 @@ GROUP BY location, customer_name
 ORDER BY location, SUM(total_amount) DESC;
 ```
 
-If you want to know the employee's average performance rating and total sales, you can run this SQL.
+To know the employee's average performance rating and total sales, run this SQL:
 
 ```SQL
-SELECT e.employee_id, given_name, family_name, AVG(rating) AS average_rating,  SUM(total_amount) AS total_sales
+SELECT e.employee_id, given_name, family_name, AVG(rating) AS average_rating, SUM(total_amount) AS total_sales
 FROM catalog_postgres.hr.employees AS e,
   catalog_postgres.hr.employee_performance AS p,
   catalog_hive.sales.sales AS s
@@ -142,7 +170,7 @@ docker exec -it playground-spark bash
 ```
 
 ```shell
-spark@7a495f27b92e:/$ cd /opt/spark && /bin/bash bin/spark-sql 
+spark@container_id:/$ cd /opt/spark && /bin/bash bin/spark-sql 
 ```
 
 ```SQL
@@ -163,7 +191,7 @@ docker exec -it playground-trino bash
 ```
 
 ```shell
-trino@d2bbfccc7432:/$ trino  
+trino@container_id:/$ trino  
 ```
 
 ```SQL

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - "3307:3306"
       - "9000:9000"
       - "9083:9083"
+      - "50070:50070"
     container_name: playground-hive
     environment:
       - HADOOP_USER_NAME=root
@@ -133,3 +134,22 @@ services:
         limits:
           cpus: "1"
           memory: 1G
+
+  jupyter:
+    image: jupyter/minimal-notebook 
+    container_name: playground-jupyter
+    ports:
+      - 8888:8888
+    volumes:
+      - ./init/jupyter:/tmp/gravitino
+    entrypoint: /bin/bash /tmp/gravitino/init.sh
+    depends_on:
+      hive :
+        condition: service_healthy
+      gravitino :
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 500M

--- a/healthcheck/gravitino-healthcheck.sh
+++ b/healthcheck/gravitino-healthcheck.sh
@@ -5,11 +5,26 @@
 #
 set -ex
 
-response=$(curl -X GET -H "Content-Type: application/json" http://127.0.0.1:8090/api/version)
+max_attempts=3
+attempt=0
+success=false
 
-if echo "$response" | grep -q "\"code\":0"; then
+while [ $attempt -lt $max_attempts ]; do
+  response=$(curl -X GET -H "Content-Type: application/json" http://127.0.0.1:8090/api/version)
+  
+  if echo "$response" | grep -q "\"code\":0"; then
+    success=true
+    break
+  else
+    echo "Attempt $((attempt + 1)) failed..."
+    sleep 1
+  fi
+  
+  ((attempt++))
+done
+
+if [ "$success" = true ]; then
   exit 0
 else
-  echo "Metalake metalake_demo create failed"
   exit 1
 fi

--- a/init/jupyter/gravitino-fileset-sample.ipynb
+++ b/init/jupyter/gravitino-fileset-sample.ipynb
@@ -1,0 +1,340 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7921ace-4d57-4a8e-934c-7e49a4f268e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install hdfs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db993abd-02bd-465b-a94a-ad7ed7e0e234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hdfs import InsecureClient\n",
+    "\n",
+    "# Create a HDFS connector client\n",
+    "hdfs_client = InsecureClient('http://hive:50070', user='root')\n",
+    "\n",
+    "# List HDFS file and directories\n",
+    "print(hdfs_client.list('/user/datastrato'))\n",
+    "\n",
+    "# hdfs_client.delete(\"/user/datastrato\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcfb73be-e369-4543-b78d-fb1cd061c9e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install gravitino"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "384715f6-a200-448f-b3b2-bf03931769bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Dict, List\n",
+    "from gravitino import NameIdentifier, GravitinoAdminClient, GravitinoClient, Catalog, Fileset, FilesetChange\n",
+    "\n",
+    "# Create Gravitino admin client\n",
+    "gravitino_admin_client = GravitinoAdminClient(uri=\"http://gravitino:8090\")\n",
+    "\n",
+    "# Create metalake via Gravitino admin client\n",
+    "metalake_name=\"default\"\n",
+    "metalake_ident=NameIdentifier.of(metalake_name)\n",
+    "metalake = gravitino_admin_client.create_metalake(ident=metalake_ident,\n",
+    "                                                  comment=\"metalake comment\", \n",
+    "                                                  properties={})\n",
+    "print(metalake)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "876c1ca4-7c41-4c9d-acde-faf2fe8c3bd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Gravitino client\n",
+    "gravitino_client = GravitinoClient(uri=\"http://gravitino:8090\", metalake_name=metalake_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d74be244-fa6a-4065-bed4-ba47bc5cd32e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Dict, List\n",
+    "from gravitino import GravitinoMetalake\n",
+    "\n",
+    "# List all Gravitino metalake entity\n",
+    "metalake_list: List[GravitinoMetalake] = gravitino_admin_client.list_metalakes()\n",
+    "print(metalake_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ed1f174-8b21-4191-a1a4-14718eaa87ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create catalog via Gravition client\n",
+    "catalog_name=\"catalog\"\n",
+    "catalog_ident=NameIdentifier.of_catalog(metalake_name, catalog_name)\n",
+    "\n",
+    "catalog = gravitino_client.create_catalog(ident=catalog_ident,\n",
+    "                                          type=Catalog.Type.FILESET,\n",
+    "                                          provider=\"hadoop\", \n",
+    "                                          comment=\"\",\n",
+    "                                          properties={})\n",
+    "print(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adf8c2ec-17e2-4550-a1cd-20430d59520c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load catalog entity via Gravition client\n",
+    "catalog = gravitino_client.load_catalog(ident=catalog_ident)\n",
+    "print(catalog)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fc69b06-0c7f-4fff-a8d8-4f257399af9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create schema entity via Gravition client\n",
+    "schema_name=\"schema\"\n",
+    "schema_path=\"/user/datastrato/\"+schema_name\n",
+    "schema_hdfs_path=\"hdfs://hive:9000\"+schema_path\n",
+    "\n",
+    "schema_ident: NameIdentifier = NameIdentifier.of_schema(metalake_name, catalog_name, schema_name)\n",
+    "catalog.as_schemas().create_schema(ident=schema_ident, \n",
+    "                                   comment=\"\", \n",
+    "                                   properties={\"location\":schema_hdfs_path})\n",
+    "\n",
+    "# Check if the schema location was successfully created in HDFS\n",
+    "try:\n",
+    "    info = hdfs_client.status(schema_path)\n",
+    "    print(f\"Success: The storage location {schema_path} was successfully created.\")\n",
+    "    print(\"Details:\", info)\n",
+    "except Exception:\n",
+    "    print(f\"Faild: The storage location {schema_path} was not successfully created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ae1b3f-53a0-42c3-b9c2-3ab6ed0defd1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a managed type of Fileset\n",
+    "managed_fileset_name=\"managed_fileset\"\n",
+    "managed_fileset_path=\"/user/datastrato/\"+schema_name+\"/\"+managed_fileset_name\n",
+    "managed_fileset_hdfs_path=\"hdfs://hive:9000\"+managed_fileset_path\n",
+    "\n",
+    "managed_fileset_ident: NameIdentifier = NameIdentifier.of_fileset(metalake_name, catalog_name, schema_name, managed_fileset_name)\n",
+    "catalog.as_fileset_catalog().create_fileset(ident=managed_fileset_ident,\n",
+    "                                            type=Fileset.Type.MANAGED,\n",
+    "                                            comment=\"\",\n",
+    "                                            storage_location=managed_fileset_hdfs_path,\n",
+    "                                            properties={})\n",
+    "\n",
+    "# Check if the fileset location was successfully created in HDFS\n",
+    "try:\n",
+    "    info = hdfs_client.status(managed_fileset_path)\n",
+    "    print(f\"Success: The storage location {managed_fileset_path} was successfully created.\")\n",
+    "    print(\"Details:\", info)  # print hdfs path detail informations\n",
+    "except Exception:\n",
+    "    print(f\"Faild: The storage location {managed_fileset_path} was not successfully created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08d7b09f-e732-4c4a-aff4-8f7e0aaa61de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "external_fileset_name=\"external_fileset\"\n",
+    "external_fileset_path=\"/user/datastrato/\"+schema_name+\"/\"+external_fileset_name\n",
+    "external_fileset_hdfs_path=\"hdfs://hive:9000\"+external_fileset_path\n",
+    "\n",
+    "# Create a fileset path in HDFS in advance\n",
+    "hdfs_client.makedirs(external_fileset_path)\n",
+    "try:\n",
+    "    info = hdfs_client.status(external_fileset_path)\n",
+    "    print(f\"Success: The storage location {external_fileset_path} was successfully created.\")\n",
+    "    print(\"Details:\", info)  # print hdfs path detail informations\n",
+    "except Exception:\n",
+    "    print(f\"Faild: The storage location {external_fileset_path} was not successfully created.\")\n",
+    "\n",
+    "# Create a external type of fileset\n",
+    "external_fileset_ident: NameIdentifier = NameIdentifier.of_fileset(metalake_name, catalog_name, schema_name, external_fileset_name)\n",
+    "catalog.as_fileset_catalog().create_fileset(ident=external_fileset_ident,\n",
+    "                                            type=Fileset.Type.EXTERNAL,\n",
+    "                                            comment=\"\",\n",
+    "                                            storage_location=external_fileset_hdfs_path,\n",
+    "                                            properties={})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "097454c8-0214-4466-ac9e-164f88929853",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List all fileset\n",
+    "catalog = gravitino_client.load_catalog(ident=catalog_ident)\n",
+    "fileset_list: List[NameIdentifier] = catalog.as_fileset_catalog().list_filesets(namespace=managed_fileset_ident.namespace())\n",
+    "print(fileset_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e4761eb-9533-47f0-9078-f7efdd3a01ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load managed fileset\n",
+    "managed_fileset=gravitino_client.load_catalog(ident=catalog_ident).as_fileset_catalog().load_fileset(ident=managed_fileset_ident)\n",
+    "print(managed_fileset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ad95186-b16e-483a-97ef-3a4ddec49033",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load external fileset\n",
+    "external_fileset=gravitino_client.load_catalog(ident=catalog_ident).as_fileset_catalog().load_fileset(ident=external_fileset_ident)\n",
+    "print(external_fileset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8164406c-808c-47f4-84da-b708dc1d3d3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop managed type of fileset and deleted HDFS location\n",
+    "catalog.as_fileset_catalog().drop_fileset(ident=managed_fileset_ident)\n",
+    "\n",
+    "# Check managed type of fileset location if successfully deleted\n",
+    "try:\n",
+    "    info = hdfs_client.status(managed_fileset_path)\n",
+    "    print(f\"Faild: The storage location {managed_fileset_path} was not successfully deleted.\")\n",
+    "except Exception:\n",
+    "    print(f\"Success: The storage location {managed_fileset_path} was successfully deleted.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "741e35d2-676f-4b97-b47b-e5374168d1ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop external type of fileset, Should not be deleted HDFS location\n",
+    "catalog.as_fileset_catalog().drop_fileset(ident=external_fileset_ident)\n",
+    "\n",
+    "# Check managed type of fileset location if reserved\n",
+    "try:\n",
+    "    info = hdfs_client.status(external_fileset_path)\n",
+    "    print(f\"Success: The storage location {external_fileset_path} reserved.\")\n",
+    "except Exception:\n",
+    "    print(f\"Faild: The storage location {external_fileset_path} deleted.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db137c72-e6dd-4e07-bc09-1b18803a6e16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop schema\n",
+    "catalog.as_schemas().drop_schema(ident=schema_ident, cascade=True)\n",
+    "\n",
+    "# Check schema location if successfully deleted\n",
+    "try:\n",
+    "    info = hdfs_client.status(schema_path)\n",
+    "    print(f\"Faild: The storage location {schema_path} was not successfully deleted.\")\n",
+    "except Exception:\n",
+    "    print(f\"Success: The storage location {schema_path} was successfully deleted.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb4cfd65-6d8c-4b67-b8ad-7aad991888f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop catalog\n",
+    "result=gravitino_client.drop_catalog(ident=catalog_ident)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00309040-edd0-4d48-ab36-a6c598294ed7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop metalake\n",
+    "result=gravitino_admin_client.drop_metalake(metalake_ident)\n",
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/init/jupyter/init.sh
+++ b/init/jupyter/init.sh
@@ -1,0 +1,6 @@
+#
+# Copyright 2024 Datastrato Pvt Ltd.
+# This software is licensed under the Apache License version 2.
+#
+cp -r /tmp/gravitino/*.ipynb /home/jovyan
+start-notebook.sh --NotebookApp.token=''

--- a/launch-playground.sh
+++ b/launch-playground.sh
@@ -3,7 +3,7 @@
 # Copyright 2023 Datastrato Pvt Ltd.
 # This software is licensed under the Apache License version 2.
 #
-#set -ex
+# set -ex
 playground_dir="$(dirname "${BASH_SOURCE-$0}")"
 playground_dir="$(cd "${playground_dir}">/dev/null; pwd)"
 isExist=`which docker-compose`
@@ -15,8 +15,20 @@ else
   exit
 fi
 
+components=""
+case "${1}" in
+  bigdata)
+    components="hive gravitino trino postgresql mysql spark"
+    ;;
+  ai)
+    components="hive gravitino mysql jupyter"
+    ;;
+  *)
+    components=$@
+esac
+
 cd ${playground_dir}
-docker-compose up
+docker-compose up ${components}
 
 # Clean Docker containers when you quit this script
 docker-compose down


### PR DESCRIPTION
1. Currently, Gravitino have own Python client, we need have a Python notebook environment to execute and use it.
So, I think add Jupyter into playground.
2. Added params `bigdata` and `ai` for `launch-playground.sh` 

   + `./launch-playground.sh bigdata`
   + `./launch-playground.sh ai`, Open http://localhost:8888 in you brower

4. Added `gravitino-fileset-sample.ipynb` into jupyter, You can use it to explore Gravitino Python client integration HDFS

#36 

<img width="1116" alt="image" src="https://github.com/datastrato/gravitino-playground/assets/3677382/38dd394c-46da-48b0-81aa-18fb1c20f388">


![gravitino-jupyter2](https://github.com/datastrato/gravitino-playground/assets/3677382/ebc184d4-5556-4451-bf25-eaaf054d66bc)


