### PR TITLE
[#41] add missing Hive port info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Install Git and Docker Compose.
 
 The playground runs a number of services. The TCP ports used may clash with existing services you run, such as MySQL or Postgres.
 
-| Docker container      | Ports used     |
-|-----------------------|----------------|
-| playground-gravitino  | 8090 9001      |
-| playground-hive       | 3307 9000 9083 |
-| playground-mysql      | 3306           |
-| playground-postgresql | 5342           |
-| playground-trino      | 8080           |
-| playground-jupyter    | 8888           |
+| Docker container      | Ports used           |
+|-----------------------|----------------------|
+| playground-gravitino  | 8090 9001            |
+| playground-hive       | 3307 9000 9083 50070 |
+| playground-mysql      | 3306                 |
+| playground-postgresql | 5342                 |
+| playground-trino      | 8080                 |
+| playground-jupyter    | 8888                 |
 
 ## Start playground
 


### PR DESCRIPTION
Hive `50070` port missing from [README](https://github.com/datastrato/gravitino-playground?tab=readme-ov-file#tcp-ports-used )